### PR TITLE
Using displayname instead of name in /modlist

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,20 @@
+# Eclipse stuff
+/.classpath
+/.project
+/.settings
+
+# NetBeans
+/nbproject
+/build.xml
+
+# vim
+.*.sw[a-p]
+
+# various other potential build files
+/build
+/bin
+/dist
+/*.jardesc
+
+# Mac filesystem dust
+.DS_Store

--- a/src/com/nyancraft/reportrts/command/ModlistCommand.java
+++ b/src/com/nyancraft/reportrts/command/ModlistCommand.java
@@ -15,16 +15,19 @@ public class ModlistCommand implements CommandExecutor{
 
         Player[] players = sender.getServer().getOnlinePlayers();
         String staff = "";
+        String separator = Message.parse("modlistMessageSeparator");
 
         for(Player player : players){
-            if(RTSPermissions.isModerator(player)) staff = staff + player.getName() + ", ";
+            if(RTSPermissions.isModerator(player)) staff = staff + player.getDisplayName() + separator;
         }
         if(staff.length() == 0){
             sender.sendMessage(Message.parse("modlistNoMods"));
             return true;
         }
-        staff = staff.substring(0, staff.length() - 2);
+        staff = staff.substring(0, staff.length() - separator.length());
 
+        
+        
         sender.sendMessage(Message.parse("modlistMessage", staff));
         return true;
     }

--- a/src/config.yml
+++ b/src/config.yml
@@ -60,6 +60,7 @@ messages:
   modreqTooManyOpen: '%red%You have too many requests open, please wait before filing more.'
   modreqTooFast: '%red%You need to wait {0} seconds before attempting to file another request.'
   modlistMessage: '%aqua%Staff online: %yellow%{0}'
+  modlistMessageSeparator: '%yellow%, '
   modlistNoMods: '%yellow%There are no staff members online.'
   reopenedRequest: '%gold%{0} has reopened request #{1}'
   reopenedRequestSelf: '%gold%Request #{0} has been reopened.'


### PR DESCRIPTION
On my server the displayname contains a color. With this improvement the color is preserved.
