### PR TITLE
Simplify RTSPermissions and remove Vault dependency.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,11 +24,6 @@
             <artifactId>bukkit</artifactId>
             <version>1.4.7-R1.0</version>
         </dependency>
-        <dependency>
-            <groupId>net.milkbowl.vault</groupId>
-            <artifactId>Vault</artifactId>
-            <version>1.2.22-SNAPSHOT</version>
-        </dependency>
     </dependencies>
     <profiles>
         <profile>

--- a/src/main/java/com/nyancraft/reportrts/RTSPermissions.java
+++ b/src/main/java/com/nyancraft/reportrts/RTSPermissions.java
@@ -8,253 +8,86 @@ import com.nyancraft.reportrts.util.Message;
 
 public class RTSPermissions {
 
+    public static boolean hasPermission(CommandSender sender, String permission){
+        if(!sender.hasPermission(permission)){
+            sender.sendMessage(Message.parse("generalPermissionError", permission));
+        }
+        return sender.hasPermission(permission);
+    }
+
     public static boolean isModerator(Player player){
-        if(ReportRTS.permission != null) return ReportRTS.permission.playerHas(player, "reportrts.mod");
-        return player.hasPermission("reportrts.mod");
+        return hasPermission(player, "reportrts.mod");
     }
 
     public static boolean canFileRequest(CommandSender sender){
-        if(ReportRTS.permission != null){
-            if(!ReportRTS.permission.has(sender, "reportrts.command.modreq")){
-                sender.sendMessage(Message.parse("generalPermissionError", "reportrts.command.modreq"));
-                return false;
-            }
-            return true;
-        }
-        if(!sender.hasPermission("reportrts.command.modreq")){
-            sender.sendMessage(Message.parse("generalPermissionError", "reportrts.command.modreq"));
-            return false;
-        }
-        return true;
+        return hasPermission(sender, "reportrts.command.modreq");
     }
 
     public static boolean canCheckAllRequests(CommandSender sender){
-        if(ReportRTS.permission != null) return ReportRTS.permission.has(sender, "reportrts.command.check");
-        return sender.hasPermission("reportrts.command.check");
+        return hasPermission(sender, "reportrts.command.check");
     }
 
     public static boolean canCheckOwnRequests(CommandSender sender){
-        if(ReportRTS.permission != null) return ReportRTS.permission.has(sender, "reportrts.command.check.self");
-        return sender.hasPermission("reportrts.command.check.self");
+        return hasPermission(sender, "reportrts.command.check.self");
     }
 
     public static boolean canCompleteRequests(CommandSender sender){
-        if(ReportRTS.permission != null) return ReportRTS.permission.has(sender, "reportrts.command.complete");
-        return sender.hasPermission("reportrts.command.complete");
+        return hasPermission(sender, "reportrts.command.complete");
     }
 
     public static boolean canCompleteOwnRequests(CommandSender sender){
-        if(ReportRTS.permission != null) return ReportRTS.permission.has(sender, "reportrts.command.complete.self");
-        return sender.hasPermission("reportrts.command.complete.self");
+        return hasPermission(sender, "reportrts.command.complete.self");
     }
 
     public static boolean canTeleport(CommandSender sender){
-        if(ReportRTS.permission != null){
-            if(!ReportRTS.permission.has(sender, "reportrts.command.teleport")){
-                sender.sendMessage(Message.parse("generalPermissionError", "reportrts.command.teleport"));
-                return false;
-            }
-            return true;
-        }
-        if(!sender.hasPermission("reportrts.command.teleport")){
-            sender.sendMessage(Message.parse("generalPermissionError", "reportrts.command.teleport"));
-            return false;
-        }
-        return true;
+        return hasPermission(sender, "reportrts.command.teleport");
     }
 
     public static boolean canReloadPlugin(CommandSender sender){
-        if(ReportRTS.permission != null){
-            if(!ReportRTS.permission.has(sender, "reportrts.command.reload")){
-                sender.sendMessage(Message.parse("generalPermissionError", "reportrts.command.reload"));
-                return false;
-            }
-            return true;
-        }
-        if(!sender.hasPermission("reportrts.command.reload")){
-            sender.sendMessage(Message.parse("generalPermissionError", "reportrts.command.reload"));
-            return false;
-        }
-        return true;
+        return hasPermission(sender, "reportrts.command.reload");
     }
 
     public static boolean canBanUser(CommandSender sender){
-        if(ReportRTS.permission != null){
-            if(!ReportRTS.permission.has(sender, "reportrts.command.ban")){
-                sender.sendMessage(Message.parse("generalPermissionError", "reportrts.command.ban"));
-                return false;
-            }
-            return true;
-        }
-        if(!sender.hasPermission("reportrts.command.ban")){
-            sender.sendMessage(Message.parse("generalPermissionError", "reportrts.command.ban"));
-            return false;
-        }
-        return true;
+        return hasPermission(sender, "reportrts.command.ban");
     }
 
     public static boolean canResetPlugin(CommandSender sender){
-        if(ReportRTS.permission != null){
-            if(!ReportRTS.permission.has(sender, "reportrts.command.reset")){
-                sender.sendMessage(Message.parse("generalPermissionError", "reportrts.command.reset"));
-                return false;
-            }
-            return true;
-        }
-        if(!sender.hasPermission("reportrts.command.reset")){
-            sender.sendMessage(Message.parse("generalPermissionError", "reportrts.command.reset"));
-            return false;
-        }
-        return true;
+        return hasPermission(sender, "reportrts.command.reset");
     }
 
     public static boolean canPutTicketOnHold(CommandSender sender){
-        if(ReportRTS.permission != null){
-            if(!ReportRTS.permission.has(sender, "reportrts.command.hold")){
-                sender.sendMessage(Message.parse("generalPermissionError", "reportrts.command.hold"));
-                return false;
-            }
-            return true;
-        }
-        if(!sender.hasPermission("reportrts.command.hold")){
-            sender.sendMessage(Message.parse("generalPermissionError", "reportrts.command.hold"));
-            return false;
-        }
-        return true;
+        return hasPermission(sender, "reportrts.command.hold");
     }
 
     public static boolean canClaimTicket(CommandSender sender){
-        if(ReportRTS.permission != null){
-            if(!ReportRTS.permission.has(sender, "reportrts.command.claim")){
-                sender.sendMessage(Message.parse("generalPermissionError", "reportrts.command.claim"));
-                return false;
-            }
-            return true;
-        }
-        if(!sender.hasPermission("reportrts.command.claim")){
-            sender.sendMessage(Message.parse("generalPermissionError", "reportrts.command.claim"));
-            return false;
-        }
-        return true;
+        return hasPermission(sender, "reportrts.command.claim");
     }
 
     public static boolean canListStaff(CommandSender sender){
-        if(ReportRTS.permission != null){
-            if(!ReportRTS.permission.has(sender, "reportrts.command.modlist")){
-                sender.sendMessage(Message.parse("generalPermissionError", "reportrts.command.modlist"));
-                return false;
-            }
-            return true;
-        }
-        if(!sender.hasPermission("reportrts.command.modlist")){
-            sender.sendMessage(Message.parse("generalPermissionError", "reportrts.command.modlist"));
-            return false;
-        }
-        return true;
+        return hasPermission(sender, "reportrts.command.modlist");
     }
 
     public static boolean canBroadcast(CommandSender sender){
-        if(ReportRTS.permission != null){
-            if(!ReportRTS.permission.has(sender, "reportrts.command.broadcast")){
-                sender.sendMessage(Message.parse("generalPermissionError", "reportrts.command.broadcast"));
-                return false;
-            }
-            return true;
-        }
-        if(!sender.hasPermission("reportrts.command.broadcast")){
-            sender.sendMessage(Message.parse("generalPermissionError", "reportrts.command.broadcast"));
-            return false;
-        }
-        return true;
-    }
-
-    public static boolean canImport(CommandSender sender){
-        if(ReportRTS.permission != null){
-            if(!ReportRTS.permission.has(sender, "reportrts.command.import")){
-                sender.sendMessage(Message.parse("generalPermissionError", "reportrts.command.import"));
-                return false;
-            }
-            return true;
-        }
-        if(!sender.hasPermission("reportrts.command.import")){
-            sender.sendMessage(Message.parse("generalPermissionError", "reportrts.command.import"));
-            return false;
-        }
-        return true;
+        return hasPermission(sender, "reportrts.command.broadcast");
     }
 
     public static boolean canCheckStats(CommandSender sender){
-        if(ReportRTS.permission != null){
-            if(!ReportRTS.permission.has(sender, "reportrts.command.stats")){
-                sender.sendMessage(Message.parse("generalPermissionError", "reportrts.command.stats"));
-                return false;
-            }
-            return true;
-        }
-        if(!sender.hasPermission("reportrts.command.stats")){
-            sender.sendMessage(Message.parse("generalPermissionError", "reportrts.command.stats"));
-            return false;
-        }
-        return true;
+        return hasPermission(sender, "reportrts.command.stats");
     }
 
     public static boolean canOverride(CommandSender sender){
-        if(ReportRTS.permission != null){
-            if(!ReportRTS.permission.has(sender, "reportrts.override")){
-                sender.sendMessage(Message.parse("generalPermissionError", "reportrts.override"));
-                return false;
-            }
-            return true;
-        }
-        if(!sender.hasPermission("reportrts.override")){
-            sender.sendMessage(Message.parse("generalPermissionError", "reportrts.override"));
-            return false;
-        }
-        return true;
+        return hasPermission(sender, "reportrts.override");
     }
 
     public static boolean canSeeHelpPage(CommandSender sender){
-        if(ReportRTS.permission != null){
-            if(!ReportRTS.permission.has(sender, "reportrts.command.help")){
-                sender.sendMessage(Message.parse("generalPermissionError", "reportrts.command.help"));
-                return false;
-            }
-            return true;
-        }
-        if(!sender.hasPermission("reportrts.command.help")){
-            sender.sendMessage(Message.parse("generalPermissionError", "reportrts.command.help"));
-            return false;
-        }
-        return true;
+        return hasPermission(sender, "reportrts.command.help");
     }
 
     public static boolean canManageNotifications(CommandSender sender){
-        if(ReportRTS.permission != null){
-            if(!ReportRTS.permission.has(sender, "reportrts.command.notifications")){
-                sender.sendMessage(Message.parse("generalPermissionError", "reportrts.command.notifications"));
-                return false;
-            }
-            return true;
-        }
-        if(!sender.hasPermission("reportrts.command.notifications")){
-            sender.sendMessage(Message.parse("generalPermissionError", "reportrts.command.notifications"));
-            return false;
-        }
-        return true;
+        return hasPermission(sender, "reportrts.command.notifications");
     }
 
     public static boolean canAssignRequests(CommandSender sender){
-        if(ReportRTS.permission != null){
-            if(!ReportRTS.permission.has(sender, "reportrts.command.assign")){
-                sender.sendMessage(Message.parse("generalPermissionError", "reportrts.command.assign"));
-                return false;
-            }
-            return true;
-        }
-        if(!sender.hasPermission("reportrts.command.assign")){
-            sender.sendMessage(Message.parse("generalPermissionError", "reportrts.command.assign"));
-            return false;
-        }
-        return true;
+        return hasPermission(sender, "reportrts.command.assign");
     }
 }

--- a/src/main/java/com/nyancraft/reportrts/ReportRTS.java
+++ b/src/main/java/com/nyancraft/reportrts/ReportRTS.java
@@ -14,10 +14,8 @@ import com.nyancraft.reportrts.data.HelpRequest;
 import com.nyancraft.reportrts.util.Message;
 import com.nyancraft.reportrts.util.MessageHandler;
 import com.nyancraft.reportrts.util.VersionChecker;
-import net.milkbowl.vault.permission.Permission;
 
 import org.bukkit.plugin.PluginManager;
-import org.bukkit.plugin.RegisteredServiceProvider;
 import org.bukkit.plugin.java.JavaPlugin;
 
 public class ReportRTS extends JavaPlugin{
@@ -49,8 +47,6 @@ public class ReportRTS extends JavaPlugin{
     public String storagePassword;
     public String versionString;
 
-    public static Permission permission = null;
-
     public void onDisable(){
         DatabaseManager.getDatabase().disconnect();
         messageHandler.saveMessageConfig();
@@ -79,7 +75,6 @@ public class ReportRTS extends JavaPlugin{
         getCommand("modlist").setExecutor(new ModlistCommand());
         getCommand("mod-broadcast").setExecutor(new ModBroadcastCommand(plugin));
         getCommand("assign").setExecutor(new AssignCommand(plugin));
-        if(getServer().getPluginManager().getPlugin("Vault") != null) setupPermissions();
         try{
             MetricsLite metrics = new MetricsLite(this);
             metrics.start();
@@ -137,14 +132,5 @@ public class ReportRTS extends JavaPlugin{
 
     public static MessageHandler getMessageHandler(){
         return messageHandler;
-    }
-
-    private Boolean setupPermissions(){
-        RegisteredServiceProvider<Permission> permissionProvider = getServer().getServicesManager().getRegistration(net.milkbowl.vault.permission.Permission.class);
-        if(permissionProvider != null){
-            permission = permissionProvider.getProvider();
-            log.info("[ReportRTS] Vault and a compatible permissions manager was found. Using Vault for permissions.");
-        }
-        return (permission != null);
     }
 }

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -2,7 +2,7 @@ name: ${name}
 main: com.nyancraft.reportrts.ReportRTS
 version: ${version}
 author: ProjectInfinity
-softdepend: [Vault]
+
 commands:
   modreq:
     description: Request help from staff
@@ -102,5 +102,5 @@ permissions:
     description: Permission to manage notifications.
     default: op
   reportrts.command.assign:
-    description: Permissions to assign requests.
+    description: Permission to assign requests.
     default: op


### PR DESCRIPTION
This commit will make RTSPermissions check the built-in SuperPerms instead of Vault for permissions (permissions plugins should implement SuperPerms instead of Vault, anyways). Also, permission checks have been changed from something like this:

``` java
public static boolean isModerator(Player player){
    if(ReportRTS.permission != null) return ReportRTS.permission.playerHas(player, "reportrts.mod");
    return player.hasPermission("reportrts.mod");
}
```

to something like this:

``` java
public static boolean isModerator(Player player){
    return hasPermission(player, "reportrts.mod")
}
```

This also adds a simple check to see if a player has a permission (and also send the player a message if they don't so `Message.parse` is not necessary in every permission check):

``` java
public static boolean hasPermission(CommandSender sender, String permission){
    if(!sender.hasPermission(permission)){
        sender.sendMessage(Message.parse("generalPermissionError", permission));
    }
}
```

I don't know how exactly this will impact performance (it _may_ be a bit slower since there are now more checks), but I can imagine the impact (if any) is minimal. Also, I'm assuming there's no more need for `ReportRTS.permission != null` since this moves towards SuperPerms (thus also removing the need for double code blocks for _both_ SuperPerms and Vault).

Plus, it makes the code look somewhat cleaner. 

Finally, this commit removes the stray "canImport" check since import support was dropped anyways.
