### PR TITLE
Fixing squid:S1118 - Utility classes should not have public constructors

### DIFF
--- a/src/main/java/com/nyancraft/reportrts/RTSFunctions.java
+++ b/src/main/java/com/nyancraft/reportrts/RTSFunctions.java
@@ -19,6 +19,9 @@ public class RTSFunctions {
     private static final int HOUR_MILLIS = 60 * MINUTE_MILLIS;
     private static final int DAY_MILLIS = 24 * HOUR_MILLIS;
 
+    private RTSFunctions() {
+    }
+
     /**
      * Join a String[] into a single string with a joiner
      */

--- a/src/main/java/com/nyancraft/reportrts/RTSPermissions.java
+++ b/src/main/java/com/nyancraft/reportrts/RTSPermissions.java
@@ -7,6 +7,9 @@ import com.nyancraft.reportrts.util.Message;
 
 public class RTSPermissions {
 
+    private RTSPermissions() {
+    }
+
     public static boolean isStaff(Player player) {
         if(ReportRTS.permission != null) return ReportRTS.permission.playerHas(player, "reportrts.staff");
         return player.hasPermission("reportrts.staff");

--- a/src/main/java/com/nyancraft/reportrts/api/Response.java
+++ b/src/main/java/com/nyancraft/reportrts/api/Response.java
@@ -7,6 +7,9 @@ import java.util.Map;
 
 public class Response {
 
+    private Response() {
+    }
+
     public static String getTickets(){
 
         StringBuilder resp = new StringBuilder();

--- a/src/main/java/com/nyancraft/reportrts/command/sub/AssignTicket.java
+++ b/src/main/java/com/nyancraft/reportrts/command/sub/AssignTicket.java
@@ -19,6 +19,9 @@ public class AssignTicket {
     private static ReportRTS plugin = ReportRTS.getPlugin();
     private static DataProvider data = plugin.getDataProvider();
 
+    private AssignTicket() {
+    }
+
     /**
      * Initial handling of the AssignTicket sub-command.
      * @param sender player that sent the command

--- a/src/main/java/com/nyancraft/reportrts/command/sub/BroadcastMessage.java
+++ b/src/main/java/com/nyancraft/reportrts/command/sub/BroadcastMessage.java
@@ -15,6 +15,9 @@ public class BroadcastMessage {
 
     private static ReportRTS plugin = ReportRTS.getPlugin();
 
+    private BroadcastMessage() {
+    }
+
     /**
      * Initial handling of the Broadcast sub-command.
      * @param sender player that sent the command

--- a/src/main/java/com/nyancraft/reportrts/command/sub/ClaimTicket.java
+++ b/src/main/java/com/nyancraft/reportrts/command/sub/ClaimTicket.java
@@ -18,6 +18,9 @@ public class ClaimTicket {
     private static ReportRTS plugin = ReportRTS.getPlugin();
     private static DataProvider data = plugin.getDataProvider();
 
+    private ClaimTicket() {
+    }
+
     /**
      * Initial handling of the Claim sub-command.
      * @param sender player that sent the command

--- a/src/main/java/com/nyancraft/reportrts/command/sub/CloseTicket.java
+++ b/src/main/java/com/nyancraft/reportrts/command/sub/CloseTicket.java
@@ -22,6 +22,9 @@ public class CloseTicket {
     private static ReportRTS plugin = ReportRTS.getPlugin();
     private static DataProvider data = plugin.getDataProvider();
 
+    private CloseTicket() {
+    }
+
     /**
      * Initial handling of the Close sub-command.
      * @param sender player that sent the command

--- a/src/main/java/com/nyancraft/reportrts/command/sub/CommentTicket.java
+++ b/src/main/java/com/nyancraft/reportrts/command/sub/CommentTicket.java
@@ -22,6 +22,9 @@ public class CommentTicket {
     private static ReportRTS plugin = ReportRTS.getPlugin();
     private static DataProvider data = plugin.getDataProvider();
 
+    private CommentTicket() {
+    }
+
     /**
      * Initial handling of the comment sub-command.
      *

--- a/src/main/java/com/nyancraft/reportrts/command/sub/HoldTicket.java
+++ b/src/main/java/com/nyancraft/reportrts/command/sub/HoldTicket.java
@@ -20,6 +20,9 @@ public class HoldTicket {
     private static ReportRTS plugin = ReportRTS.getPlugin();
     private static DataProvider data = plugin.getDataProvider();
 
+    private HoldTicket() {
+    }
+
     /**
      * Initial handling of the Hold sub-command.
      * @param sender player that sent the command

--- a/src/main/java/com/nyancraft/reportrts/command/sub/ListStaff.java
+++ b/src/main/java/com/nyancraft/reportrts/command/sub/ListStaff.java
@@ -12,6 +12,9 @@ public class ListStaff {
 
     private static ReportRTS plugin = ReportRTS.getPlugin();
 
+    private ListStaff() {
+    }
+
     /**
      * Initial handling of the Staff sub-command.
      * @param sender player that sent the command

--- a/src/main/java/com/nyancraft/reportrts/command/sub/OpenTicket.java
+++ b/src/main/java/com/nyancraft/reportrts/command/sub/OpenTicket.java
@@ -24,6 +24,9 @@ public class OpenTicket {
     private static ReportRTS plugin = ReportRTS.getPlugin();
     private static DataProvider data = plugin.getDataProvider();
 
+    private OpenTicket() {
+    }
+
     /**
      * Initial handling of the Open sub-command.
      * @param sender player that sent the command

--- a/src/main/java/com/nyancraft/reportrts/command/sub/ReadTicket.java
+++ b/src/main/java/com/nyancraft/reportrts/command/sub/ReadTicket.java
@@ -29,6 +29,9 @@ public class ReadTicket {
     private static SimpleDateFormat sdf = new SimpleDateFormat("MMM.dd kk:mm z");
     private static String substring;
 
+    private ReadTicket() {
+    }
+
     /**
      * Initial handling of the Read sub-command.
      * @param sender player that sent the command

--- a/src/main/java/com/nyancraft/reportrts/command/sub/ReopenTicket.java
+++ b/src/main/java/com/nyancraft/reportrts/command/sub/ReopenTicket.java
@@ -19,6 +19,9 @@ public class ReopenTicket {
     private static ReportRTS plugin = ReportRTS.getPlugin();
     private static DataProvider data = plugin.getDataProvider();
 
+    private ReopenTicket() {
+    }
+
     /**
      * Initial handling of the Reopen sub-command.
      * @param sender player that sent the command

--- a/src/main/java/com/nyancraft/reportrts/command/sub/TeleportTicket.java
+++ b/src/main/java/com/nyancraft/reportrts/command/sub/TeleportTicket.java
@@ -20,6 +20,9 @@ public class TeleportTicket {
     private static ReportRTS plugin = ReportRTS.getPlugin();
     private static DataProvider data = plugin.getDataProvider();
 
+    private TeleportTicket() {
+    }
+
     /**
      * Initial handling of the Teleport sub-command.
      * @param sender player that sent the command

--- a/src/main/java/com/nyancraft/reportrts/command/sub/UnclaimTicket.java
+++ b/src/main/java/com/nyancraft/reportrts/command/sub/UnclaimTicket.java
@@ -18,6 +18,9 @@ public class UnclaimTicket {
     private static ReportRTS plugin = ReportRTS.getPlugin();
     private static DataProvider data = plugin.getDataProvider();
 
+    private UnclaimTicket() {
+    }
+
     /**
      * Initial handling of the Unclaim sub-command.
      * @param sender player that sent the command

--- a/src/main/java/com/nyancraft/reportrts/util/BungeeCord.java
+++ b/src/main/java/com/nyancraft/reportrts/util/BungeeCord.java
@@ -20,6 +20,9 @@ public class BungeeCord {
 
     private static String serverName;
 
+    private BungeeCord() {
+    }
+
     public static void processPendingRequests(){
         if(!pendingRequests.isEmpty()){
             for(byte[] toSend : pendingRequests){

--- a/src/main/java/com/nyancraft/reportrts/util/Message.java
+++ b/src/main/java/com/nyancraft/reportrts/util/Message.java
@@ -9,6 +9,9 @@ import com.nyancraft.reportrts.ReportRTS;
 
 public class Message {
 
+    private Message() {
+    }
+
     private static String parse(String key, Object ... params ){
         Object prop = ReportRTS.getMessageHandler().messageMap.get(key);
         if(prop == null) {


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule
squid:S1118 - "Utility classes should not have public constructors".
You can find more information about the issue here:
https://sonar.spring.io/coding_rules#rule_key=squid:S1118
Please let me know if you have any questions.
Artyom Melnikov