### PR TITLE
Fixed NPE when closing DataProvider

### DIFF
--- a/src/main/java/com/nyancraft/reportrts/ReportRTS.java
+++ b/src/main/java/com/nyancraft/reportrts/ReportRTS.java
@@ -79,7 +79,9 @@ public class ReportRTS extends JavaPlugin implements PluginMessageListener {
     private String serverIP;
 
     public void onDisable() {
-        provider.close();
+        if (provider != null) {
+            provider.close();
+        }
         if(apiEnabled) {
             try{
                 apiServer.getListener().close();


### PR DESCRIPTION
Prevents an exception from being thrown if the server is shutdown or the plugin is restarted/reloaded before the setup is complete.